### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   RUST_BACKTRACE: 1
   CARGO_TERM_VERBOSE: "true"


### PR DESCRIPTION
Potential fix for [https://github.com/Resonaa/polygen/security/code-scanning/1](https://github.com/Resonaa/polygen/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the `contents: read` permission is sufficient for most steps, and no additional permissions are explicitly required for the `GITHUB_TOKEN`. This ensures that the workflow adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
